### PR TITLE
Move optional parameters after required to comply with PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "ilovepdf/ilovepdf-php",
+    "name": "eswachsman/ilovepdf-api",
     "description": "iLovePDF Php Api for PHP 8",
     "type": "library",
     "homepage": "https://ilovepdf.com/",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "eswachsman/ilovepdf-php",
+    "name": "ilovepdf/ilovepdf-php",
     "description": "iLovePDF Php Api for PHP 8",
     "type": "library",
     "homepage": "https://ilovepdf.com/",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "ilovepdf/ilovepdf-php",
-    "description": "iLovePDF Php Api",
+    "name": "eswachsman/ilovepdf-php",
+    "description": "iLovePDF Php Api for PHP 8",
     "type": "library",
     "homepage": "https://ilovepdf.com/",
     "license": "MIT",

--- a/src/Exceptions/ExtendedException.php
+++ b/src/Exceptions/ExtendedException.php
@@ -17,7 +17,7 @@ class ExtendedException extends Exception
      * @param Exception|null $previous
      * @param $response
      */
-    public function __construct($message, $code = 0, Exception $previous = null, $response)
+    public function __construct($message, $response, $code = 0, Exception $previous = null)
     {
         if (isset($response->body->error) && $response->body->error->type) {
             $this->type = $response->body->error->type;

--- a/src/Ilovepdf.php
+++ b/src/Ilovepdf.php
@@ -193,10 +193,10 @@ class Ilovepdf
                 throw new UploadException($response->body->error->message, $response, $response->code, null);
             }
             elseif ($endpoint == 'process') {
-                throw new ProcessException($response->body->error->message, $response $response->code, null);
+                throw new ProcessException($response->body->error->message, $response, $response->code, null);
             }
             elseif (strpos($endpoint, 'download')===0) {
-                throw new DownloadException($response->body->error->message, $response $response->code, null);
+                throw new DownloadException($response->body->error->message, $response, $response->code, null);
             }
             else{
                 if ($response->code == 400) {

--- a/src/Ilovepdf.php
+++ b/src/Ilovepdf.php
@@ -184,19 +184,19 @@ class Ilovepdf
 
         if ($response->code != '200' && $response->code != '201') {
             if ($response->code == 401) {
-                throw new AuthException($response->body->name, $response->code, null, $response);
+                throw new AuthException($response->body->name, $response, $response->code, null);
             }
             if ($endpoint == 'upload') {
                 if(is_string($response->body)){
-                    throw new UploadException("Upload error", $response->code, null, $response);
+                    throw new UploadException("Upload error", $response, $response->code, null);
                 }
-                throw new UploadException($response->body->error->message, $response->code, null, $response);
+                throw new UploadException($response->body->error->message, $response, $response->code, null);
             }
             elseif ($endpoint == 'process') {
-                throw new ProcessException($response->body->error->message, $response->code, null, $response);
+                throw new ProcessException($response->body->error->message, $response $response->code, null);
             }
             elseif (strpos($endpoint, 'download')===0) {
-                throw new DownloadException($response->body->error->message, $response->code, null, $response);
+                throw new DownloadException($response->body->error->message, $response $response->code, null);
             }
             else{
                 if ($response->code == 400) {


### PR DESCRIPTION
In PHP 8, optional parameters must come after all required parameters. 

https://php.watch/versions/8.0/deprecate-required-param-after-optional