### PR TITLE
Remove php doc param

### DIFF
--- a/src/Ilovepdf.php
+++ b/src/Ilovepdf.php
@@ -340,7 +340,6 @@ class Ilovepdf
 
 
     /**
-     * @param bool $value
      * @param string|null $encryptKey
      * @return $this
      */


### PR DESCRIPTION
This param causes deprecation notices with Symfony DebugClassLoader