### PR TITLE
Fix PHP version constraint to match php-jwt v7 requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     },
     "require": {
-        "php": ">=7.3",
+        "php": ">=8.0",
         "firebase/php-jwt": "^7.0",
         "guzzlehttp/guzzle": "^7.4",
         "ext-json": "*"

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ Develop and automate PDF processing tasks like Compress PDF, Merge PDF, Split PD
 
 ## Requirements
 
-PHP 7.4 and later.
+PHP 8.0 and later.
 
 ## Install
 


### PR DESCRIPTION
## Summary

Follow-up to #64 — `firebase/php-jwt` was upgraded to `^7.0`, but the PHP version constraint was not updated.

## Problem
`firebase/php-jwt` v7 requires PHP >=8.0, but `composer.json` still declares `"php": ">=7.3"`. This means `composer install` on PHP 7.x will fail with an unresolvable dependency, which is confusing for users.

See: https://github.com/firebase/php-jwt/blob/main/composer.json

## Changes
- `composer.json`: `"php": ">=7.3"` → `"php": ">=8.0"`
- `readme.md`: PHP requirement updated from 7.4 to 8.0

## Why this is safe
- PHP 7.3 EOL: December 2021
- PHP 7.4 EOL: November 2022
- No code changes needed — `JWT::encode()` API is identical in v7
- firebase/php-jwt v6.x was affected by CVE-2025-45769 (see: https://github.com/advisories/GHSA-2x45-7fc3-mxwq)